### PR TITLE
Spelling correction for brew recipe

### DIFF
--- a/lists/brew
+++ b/lists/brew
@@ -7,7 +7,7 @@ carthage
 cf-cli
 chruby
 cloc
-contconfig
+fontconfig
 credhub-cli
 ctags
 curl


### PR DESCRIPTION
I couldn't find anything in brew called contconfig and figured you meant fontconfig maybe